### PR TITLE
Add hashid and s3direct 'support'

### DIFF
--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -1,6 +1,8 @@
 from django.db.models import *
 from django.conf import settings
 from django.utils import timezone
+from s3direct.fields import S3DirectField
+from hashid_field import HashidField
 
 import random
 import re
@@ -105,4 +107,7 @@ class FieldTypeGuesser(object):
             return lambda x: _timezone_format(faker.date_time())
         if isinstance(field, DateField): return lambda x: faker.date()
         if isinstance(field, TimeField): return lambda x: faker.time()
+
+        if isinstance(field, S3DirectField): return lambda x: faker.uri()
+        if isinstance(field, HashidField): return lambda x: provider.rand_small_int(pos=True)
         raise AttributeError(field)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 django
 Faker
+s3direct
+django-hashid-field


### PR DESCRIPTION
This commit adds 'support' for hashid fields, and s3direct fields.
It isnt really great support. It technically functions, but these
generator functions used are not the best possible for these data
types. They are, however, sufficient for our requirements.